### PR TITLE
Import Bill properties as boolean values

### DIFF
--- a/import.cypher
+++ b/import.cypher
@@ -43,9 +43,12 @@ LOAD CSV WITH HEADERS
 FROM 'file:///bills.csv'
 AS line
 MERGE (bill:Bill { billID: line.billID })
-    ON CREATE SET bill = line;
+    ON CREATE SET bill = line,
+      bill.enacted = (CASE line.enacted WHEN 'False' THEN false ELSE true END),
+      bill.vetoed = (CASE line.vetoed WHEN 'False' THEN false ELSE true END),
+      bill.active = (CASE line.active WHEN 'False' THEN false ELSE true END);
 
-// Load 
+// Load Subjects
 
 LOAD CSV WITH HEADERS
 FROM 'file:///subjects.csv' AS line

--- a/load_bills.cql
+++ b/load_bills.cql
@@ -3,6 +3,12 @@ LOAD CSV WITH HEADERS
 FROM 'http://localhost:8000/outputs/bills.csv'
 AS line
 MERGE (bill:Bill { billID: line.billID })
-    ON CREATE SET bill = line
-    ON MATCH SET bill = line;
+    ON CREATE SET bill = line,
+      bill.enacted = (CASE line.enacted WHEN 'False' THEN false ELSE true END),
+      bill.vetoed = (CASE line.vetoed WHEN 'False' THEN false ELSE true END),
+      bill.active = (CASE line.active WHEN 'False' THEN false ELSE true END)
+    ON MATCH SET bill = line,
+      bill.enacted = (CASE line.enacted WHEN 'False' THEN false ELSE true END),
+      bill.vetoed = (CASE line.vetoed WHEN 'False' THEN false ELSE true END),
+      bill.active = (CASE line.active WHEN 'False' THEN false ELSE true END);
 CREATE INDEX ON :Bill(billID);


### PR DESCRIPTION
Import `enacted`, `active`, and `vetoed` properties as boolean values as opposed to strings.

PR for: https://github.com/legis-graph/legis-graph/issues/13