### PR TITLE
#15: pre-114th Congress bill sponsors use thomas_ids

### DIFF
--- a/import.cypher
+++ b/import.cypher
@@ -85,7 +85,7 @@ AS line
 MATCH (bill:Bill { billID: line.billID }),
       (legislator:Legislator { thomasID: line.thomasID })
 MERGE (bill)-[r:SPONSORED_BY]->(legislator)
-SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
+    ON CREATE SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
 
 // Load current bill sponsorships and co-sponsorships
 USING PERIODIC COMMIT
@@ -95,7 +95,7 @@ AS line
 MATCH (bill:Bill { billID: line.billID }),
       (legislator:Legislator { bioguideID: line.bioguideID })
 MERGE (bill)-[r:SPONSORED_BY]->(legislator)
-SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
+    ON CREATE SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
 
 // Load Votes
 

--- a/import.cypher
+++ b/import.cypher
@@ -77,17 +77,25 @@ MATCH (bill:Bill { billID: line.billID }),
       (subject:Subject { title: line.title })
 MERGE (bill)-[r:DEALS_WITH]->(subject);
 
-// Load Bills Legislators
-
-// Load current sponsorships
+// Load historical bill sponsorships and co-sponsorships
 USING PERIODIC COMMIT
 LOAD CSV WITH HEADERS
-FROM 'file:///sponsors.csv'
+FROM 'file:///sponsors-historical.csv'
+AS line
+MATCH (bill:Bill { billID: line.billID }),
+      (legislator:Legislator { thomasID: line.thomasID })
+MERGE (bill)-[r:SPONSORED_BY]->(legislator)
+SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
+
+// Load current bill sponsorships and co-sponsorships
+USING PERIODIC COMMIT
+LOAD CSV WITH HEADERS
+FROM 'file:///sponsors-current.csv'
 AS line
 MATCH (bill:Bill { billID: line.billID }),
       (legislator:Legislator { bioguideID: line.bioguideID })
 MERGE (bill)-[r:SPONSORED_BY]->(legislator)
-    ON CREATE SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN True ELSE False END;
+SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
 
 // Load Votes
 

--- a/load_bills_legislators.cql
+++ b/load_bills_legislators.cql
@@ -1,9 +1,19 @@
-// Load current sponsorships
+// Load historical bill sponsorships and co-sponsorships
 USING PERIODIC COMMIT
 LOAD CSV WITH HEADERS
-FROM 'http://localhost:8000/outputs/sponsors.csv'
+FROM 'http://localhost:8000/outputs/sponsors-historical.csv'
 AS line
 MATCH (bill:Bill { billID: line.billID }),
       (legislator:Legislator { thomasID: line.thomasID })
 MERGE (bill)-[r:SPONSORED_BY]->(legislator)
-    ON CREATE SET r.cosponsor = line.cosponsor;
+SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
+
+// Load current bill sponsorships and co-sponsorships
+USING PERIODIC COMMIT
+LOAD CSV WITH HEADERS
+FROM 'http://localhost:8000/outputs/sponsors-current.csv'
+AS line
+MATCH (bill:Bill { billID: line.billID }),
+      (legislator:Legislator { bioguideID: line.bioguideID })
+MERGE (bill)-[r:SPONSORED_BY]->(legislator)
+SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;

--- a/load_bills_legislators.cql
+++ b/load_bills_legislators.cql
@@ -6,7 +6,7 @@ AS line
 MATCH (bill:Bill { billID: line.billID }),
       (legislator:Legislator { thomasID: line.thomasID })
 MERGE (bill)-[r:SPONSORED_BY]->(legislator)
-SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
+  ON CREATE SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
 
 // Load current bill sponsorships and co-sponsorships
 USING PERIODIC COMMIT
@@ -16,4 +16,4 @@ AS line
 MATCH (bill:Bill { billID: line.billID }),
       (legislator:Legislator { bioguideID: line.bioguideID })
 MERGE (bill)-[r:SPONSORED_BY]->(legislator)
-SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;
+    ON CREATE SET r.cosponsor = CASE WHEN line.cosponsor = "1" THEN true ELSE false END;


### PR DESCRIPTION
I added [a](https://github.com/gregoryfoster/legis-graph/commit/f78f545fe95ba27047bce7b2d8588759bc685e77#commitcomment-21009074) [few](https://github.com/gregoryfoster/legis-graph/commit/f78f545fe95ba27047bce7b2d8588759bc685e77#commitcomment-21009075) [comments](https://github.com/gregoryfoster/legis-graph/commit/55e155ab7338e021b1bed841281c1871182b1cc2#commitcomment-21009033) to the commits to outline some of the substantive changes made.  I tried to hew to the pattern of `-current` and `-historical` output files, but I'd be happy to discuss implementing in another way.  Currently verified to work pulling in the 112th-114th data.